### PR TITLE
Added ruff as Python linter.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: hadolint
+name: Lint
 
 on:
   push:
@@ -8,15 +8,20 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  lint:
+    name: Run Linters
     runs-on: ubuntu-latest
 
     steps:
-      # Checks out repository under $GITHUB_WORKSPACE, so the job can access it.
+      # Checks out repository, so the job can access it.
       - uses: actions/checkout@v3
     
-      # Hadolint is a linter for the Dockerfile.
-      - name: Hadolint Action
+      - name: Hadolint Linter for Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
+
+      - name: Python Linters
+        uses: wearerequired/lint-action@v2
+        with:
+          autopep8: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,12 +16,19 @@ jobs:
       # Checks out repository, so the job can access it.
       - uses: actions/checkout@v3
     
-      - name: Hadolint Linter for Dockerfile
+      - name: Hadolint linter checks Dockerfile.
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
 
-      - name: Python Linters
-        uses: wearerequired/lint-action@v2
-        with:
-          autopep8: true
+      - name: Installs dependencies.
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lints with ruff
+        run: |
+          # Stops the build if there are Python syntax errors or undefined names.
+          ruff --format=github --select=E9,F63,F7,F82 --target-version=py310 .
+          # Uses default set of ruff rules with GitHub Annotations.
+          ruff --format=github --target-version=py310 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #   --rm  removes/deletes the container when it is finished running.
 #   --publish 8000:80  exposing container's port 80 as port 8000 on the machine that is running the container.
 
-FROM python:3.10
+FROM python:3.10.12-bookworm
 
 WORKDIR /web-service
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,7 @@ WORKDIR /web-service
 
 COPY ./requirements.txt /web-service/requirements.txt
 
-RUN apt-get update \
-  && pip install --no-cache-dir --upgrade -r /web-service/requirements.txt \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir --upgrade -r /web-service/requirements.txt
 
 COPY ./app /web-service/app
 

--- a/app/main.py
+++ b/app/main.py
@@ -12,10 +12,10 @@ def generate_greeting(name=""):
 
 
 @app.get("/greeting")
-async def greeting():
+async def generic_greeting():
     return {"message": generate_greeting()}
 
 
 @app.get("/greeting/{name}")
-async def greeting(name):
+async def greeting_by_name(name):
     return {"message": generate_greeting(name)}

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ DEFAULT_NAME = "World"
 
 app = FastAPI()
 
+
 def generate_greeting(name=""):
     if name == "":
         name = DEFAULT_NAME

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+# runtime dependencies
 fastapi==0.98.0
 uvicorn==0.22.0
+
+# development dependencies
+autopep8==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ fastapi==0.98.0
 uvicorn==0.22.0
 
 # development dependencies
-autopep8==2.0.2
+ruff==0.0.275


### PR DESCRIPTION
- Generalized `lint.yml` for different type of linters to run in GitHub Actions.
    - Adds [ruff](https://pypi.org/project/ruff/) as a Python linter.
- Cleaned up Dockerfile, removing unneeded `apt-get`.
    - Relies on base [python:3.10.12-bookwork](https://github.com/docker-library/python/blob/5d908b0477c003712550c84ac4d133367b912f78/3.10/bookworm/Dockerfile).
    - Avoids any unexpected changes that might occur from update.